### PR TITLE
Extended get_image to use native wordpress 'size' 

### DIFF
--- a/get-custom.php
+++ b/get-custom.php
@@ -205,10 +205,10 @@ function GetProcessedFieldValue($fieldValues, $fieldType, $fieldProperties=array
 				$fieldValue = date($fieldProperties['format'],strtotime($fieldValue)); 
 				break;
 		  case $FIELD_TYPES["Image (Upload Media)"]:
-		    	if ($fieldValue != ""){ 
-		    	  $data = wp_get_attachment_image_src($fieldValue,'original');
-		    	  $fieldValue = $data[0];
-		    	 }
+				if ($fieldValue != ""){ 
+					$data = wp_get_attachment_image_src($fieldValue,'original');
+					$fieldValue = $data[0];
+		    	}
   				break;
 		}
 		
@@ -325,14 +325,15 @@ function get_panel_name($safe=true, $post_id = NULL){
 }
 
 // Get Image. 
-function get_image ($fieldName, $groupIndex=1, $fieldIndex=1,$tag_img=1,$post_id=NULL,$override_params=NULL) {
+function get_image ($fieldName, $groupIndex=1, $fieldIndex=1,$tag_img=1,$post_id=NULL,$override_params=NULL, $wp_size='original') {
 	return create_image(array(
 		'fieldName' => $fieldName, 
 		'groupIndex' => $groupIndex, 
 		'fieldIndex' => $fieldIndex,
 		'param' => $override_params,
 		'post_id' => $post_id,
-		'tag_img' => (boolean) $tag_img
+		'tag_img' => (boolean) $tag_img,
+		'wp_size' => $wp_size
 	));
 }
 
@@ -378,7 +379,8 @@ function create_image($options)
 		'param' => NULL,
 		'attr' => NULL,
 		'post_id' => NULL,
-		'tag_img' => true
+		'tag_img' => true,
+		'wp_size' => 'original'
 	), (array) $options);
 	
 	// finally extract them into variables for this function
@@ -406,7 +408,7 @@ function create_image($options)
 	$fieldValue = $field['meta_value'];
 
   if($fieldType == 16){
-    $data = wp_get_attachment_image_src($fieldValue,'original');
+    $data = wp_get_attachment_image_src($fieldValue, $wp_size);
     $fieldValue = $data[0];
   }
 
@@ -933,5 +935,4 @@ function get_flat_group($name_group, $post_id = NULL) {
 function get_flat_group_with_prefix($name_group, $prefix, $post_id = NULL) {
   return get_group_with_options($name_group, array("prefix" => $prefix, "flatten" => TRUE), $post_id);
 }
-
 


### PR DESCRIPTION
I've added a couple of lines to get-custom.php to allow a native wordpress custom image size when fetching wp_get_attachment_image_src.

This allows theme builders to use "add_image_size('custom-size-name', 84, 74);" to define an image size.

Its cleaner and faster than generating an image on request as the images are created during upload.
