### PR TITLE
Shows proper name of write panel instead of just "Custom Field Magic Fields"

### DIFF
--- a/RCCWP_WritePostPage.php
+++ b/RCCWP_WritePostPage.php
@@ -362,7 +362,7 @@ class RCCWP_WritePostPage  {
 			}
 			
 			if($group->name == "__default"){
-				$name = "Magic Fields Custom Fields";
+				$name = Inflect::singularize($CUSTOM_WRITE_PANEL->name);
 			}else{
 				$name = $group->name;
 			}	


### PR DESCRIPTION
I originally had this as a Gist at https://gist.github.com/1152591

A screenshot is at http://img13.imageshack.us/img13/5820/magicfields.png

This makes it much easier for end-users to work with adding posts via Magic Fields.
