### PR TITLE
Fix for loading assets on admin pages when SSL is required

### DIFF
--- a/MF_Constant.php
+++ b/MF_Constant.php
@@ -21,7 +21,7 @@ $mfpath = str_replace('\\', '/', $mfpath);
 define('MF_PLUGIN_DIR', dirname(plugin_basename(__FILE__))); 
 define("MF_PATH", dirname(__FILE__));
 
-define("MF_URI", plugin_dir_url(__FILE__);
+define("MF_URI", plugin_dir_url(__FILE__));
 define("MF_URI_RELATIVE", 'wp-content'.$mfpath[1]);
 define("PHPTHUMB",MF_URI."thirdparty/phpthumb/phpThumb.php");
 


### PR DESCRIPTION
Fixes an issue on WordPress installations that require SSL on admin pages.

Newer versions of Chrome default to blocking assets loaded from insecure sources, 
and the current method for determining the MF_URI constant doesn't take SSL into account.
